### PR TITLE
https support

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,8 @@ var express = require('express')
 
 [express.Server || express.HTTPServer, express.HTTPSServer].forEach(function(Server) {
 	
+	if (Server == undefined) return;
+	
 	/**
 	 * Namespace using the given `path`, providing a callback `fn()`,
 	 * which will be invoked immediately, resetting the namespace to the previous.


### PR DESCRIPTION
my quick patch to add namespace support for https server instances.
## attention

express itself needs an 
    exports.HTTPSServer = HTTPSServer;

around line 52 in `lib/express.js`
