### PR TITLE
Not sure why "del" and "all" are treated separately here? It makes expres

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 /*!
  * Express - Contrib - namespace
  * Copyright(c) 2010 TJ Holowaychuk <tj@vision-media.ca>
@@ -46,7 +45,7 @@ exports.__defineGetter__('currentNamespace', function(){
  * Proxy HTTP methods to provide namespacing support.
  */
 
-express.router.methods.concat(['del', 'all']).forEach(function(method){
+express.router.methods.forEach(function(method){
   var orig = HTTPServer.prototype[method];
   exports[method] = function(){
     var args = Array.prototype.slice.call(arguments)


### PR DESCRIPTION
Not sure why "del" and "all" are treated separately here? It makes express fail on app.all() requests.
