### PR TITLE
Fix to pass tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ exports.namespace = function(){
     , path = args.shift()
     , fn = args.pop()
     , self = this;
-  self.all(path + '*', args);
+  if(args.length) self.all(path + '*', args);
   (this._ns = this._ns || []).push(path);
   fn.call(this);
   this._ns.pop();


### PR DESCRIPTION
This fix makes the tests pass.  The problem was that while `get('/', handler)` handles with or without that trailing '/', the route `get('/*', handler)` won't work without the trailing '/', so now we use `all('*', handler)`
