### PR TITLE
Compatibility with latest express

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,9 +9,7 @@
  */
 
 var express = require('express')
-  , join = require('path').join
-  , HTTPServer = express.HTTPServer
-  , HTTPSServer = express.HTTPSServer;
+  , join = require('path').join;
 
 /**
  * Namespace using the given `path`, providing a callback `fn()`,
@@ -51,8 +49,8 @@ exports.__defineGetter__('currentNamespace', function(){
  * Proxy HTTP methods to provide namespacing support.
  */
 
-express.router.methods.concat('del').forEach(function(method){
-  var orig = HTTPServer.prototype[method];
+(express.router || express.Router).methods.concat('del').forEach(function(method){
+  var orig = express.application[method];
   exports[method] = function(){
     var args = Array.prototype.slice.call(arguments)
       , path = args.shift()
@@ -78,6 +76,6 @@ express.router.methods.concat('del').forEach(function(method){
 
 for (var key in exports) {
   var desc = Object.getOwnPropertyDescriptor(exports, key);
-  Object.defineProperty(HTTPServer.prototype, key, desc);
-  Object.defineProperty(HTTPSServer.prototype, key, desc);
+  Object.defineProperty(express.application, key, desc);
+  Object.defineProperty(express.application, key, desc);
 }


### PR DESCRIPTION
Uses express.application instead of express.HTTPServer and backwards compatibility for express.router (which is now express.Router).

https://github.com/visionmedia/express-namespace/issues/6 still applies, but at least we're back to where we were. I think.
