### PR TITLE
Express 3.x  compatibility improvement (Issues#6)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 
 test:
-	@./node_modules/.bin/expresso --serial
+	@./node_modules/.bin/mocha \
+		--reporter list
 
 .PHONY: test

--- a/index.js
+++ b/index.js
@@ -56,12 +56,21 @@ exports.__defineGetter__('currentNamespace', function(){
   var orig = app[method];
   exports[method] = function(){
     var args = Array.prototype.slice.call(arguments)
+      , len  = args.length
       , path = args.shift()
       , fn = args.pop()
       , self = this;
 
+    // Prevent namepacing getter on application
+    if(method === 'get' && len === 1) {
+      return orig.apply(this,Array.prototype.slice.call(arguments));
+    }
+
+
     this.namespace(path, function(){
-      var curr = this.currentNamespace;
+      // currentNamespace property getter return an invalid path (a '.') ? - So I don't use it
+      var curr = join.apply(this, this._ns).replace(/\\/g, '/').replace(/\/$/, '') || '/';
+
       args.forEach(function(fn){
         fn.namespace = curr;
         orig.call(self, curr, fn);

--- a/index.js
+++ b/index.js
@@ -44,9 +44,9 @@ exports.namespace = function(){
  * @api public
  */
 
-exports.__defineGetter__('currentNamespace', function(){
+exports.getCurrentNamespace = function(){
   return join.apply(this, this._ns).replace(/\\/g, '/').replace(/\/$/, '') || '/';
-});
+};
 
 /**
  * Proxy HTTP methods to provide namespacing support.
@@ -68,8 +68,7 @@ exports.__defineGetter__('currentNamespace', function(){
 
 
     this.namespace(path, function(){
-      // currentNamespace property getter return an invalid path (a '.') ? - So I don't use it
-      var curr = join.apply(this, this._ns).replace(/\\/g, '/').replace(/\/$/, '') || '/';
+      var curr = this.getCurrentNamespace();
 
       args.forEach(function(fn){
         fn.namespace = curr;
@@ -88,6 +87,5 @@ exports.__defineGetter__('currentNamespace', function(){
 
 for (var key in exports) {
   var desc = Object.getOwnPropertyDescriptor(exports, key);
-  Object.defineProperty(app, key, desc);
   Object.defineProperty(app, key, desc);
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   , "devDependencies": {
       "express": "3.x"
     , "ejs": ">= 0.0.1"
-    , "expresso": ">= 0.0.1"
+    , "mocha": "1.x.x"
+    , "should": "0.6.x"
   }
   , "engines": { "node": ">= 0.2.0" }
 }

--- a/test/namespace.test.js
+++ b/test/namespace.test.js
@@ -2,21 +2,29 @@
  * Module dependencies.
  */
 
-var express = require('express')
-  , assert = require('assert')
-  , namespace = require('../');
+var express   = require('express')
+  , namespace = require('../')
+  , assert    = require('assert')
+  , should    = require('should')
+  , request   = require('./support/http');
 
-module.exports = {
-  'test app.namespace(str, fn)': function(){
-    var app = express()
-      , id;
 
-    app.get('/one', function(req, res){
-      res.send('GET one');
-    });
 
-    assert.equal(app.namespace('/user', function(){}), app);
+describe('app.namespace(str, fn)', function(){
 
+  var app = express()
+    , id;
+
+  app.get('/one', function(req, res){
+    res.send('GET one');
+  });
+
+  it('app should be equal after namespace call', function() {
+    app.namespace('/user', function(){}).should.equal(app);
+  });
+
+
+  it('should add namespace', function() {
     app.namespace('/user', function(){
       app.all('/:id', function(req, res, next){
         id = req.params.id;
@@ -35,165 +43,252 @@ module.exports = {
     app.get('/two', function(req, res){
       res.send('GET two');
     });
+  });
 
-    assert.response(app,
-      { url: '/user/12' },
-      { body: 'GET user 12' });
-  
-    assert.response(app,
-      { url: '/user/12', method: 'DELETE' },
-      { body: 'DELETE user 12' });
-    
-    assert.response(app,
-      { url: '/one' },
-      { body: 'GET one' });
-    
-    assert.response(app,
-      { url: '/two' },
-      { body: 'GET two' });
-  },
-  
-  'test app.namespace(str, fn) nesting': function(done){
-    var pending = 6
-      , calls = 0
-      , app = express();
-    
-    function finished() {
-      --pending || function(){
-        assert.equal(2, calls);
+
+  it('should get() namespaced route', function(done) {
+    request(app)
+      .get('/user/12')
+      .end(function(res) {
+        res.body.should.equal('GET user 12');
         done();
-      }();
-    }
-
-    function middleware(req, res, next) {
-      ++calls;
-      next();
-    }
-
-    app.get('/one', function(req, res){
-      res.send('GET one');
-    });
-
-    app.namespace('/forum/:id', function(){
-      app.get('/', function(req, res){
-        res.send('GET forum ' + req.params.id);
       });
-      
-      app.get('/edit', function(req, res){
-        res.send('GET forum ' + req.params.id + ' edit page');
-      });
+  });
 
-      app.namespace('/thread', function(){
-        app.get('/:tid', middleware, middleware, function(req, res){
-          res.send('GET forum ' + req.params.id + ' thread ' + req.params.tid);
-        });
-      });
-
-      app.del('/', function(req, res){
-        res.send('DELETE forum ' + req.params.id);
-      });
-    });
-    
-    app.get('/two', function(req, res){
-      res.send('GET two');
-    });
-
-    assert.response(app,
-      { url: '/forum/1' },
-      { body: 'GET forum 1' }
-      , finished);
-    
-    assert.response(app,
-      { url: '/forum/1/edit' },
-      { body: 'GET forum 1 edit page' }
-      , finished);
-    
-    assert.response(app,
-      { url: '/forum/1/thread/50' },
-      { body: 'GET forum 1 thread 50' }
-      , finished);
-  
-    assert.response(app,
-      { url: '/forum/2', method: 'DELETE' },
-      { body: 'DELETE forum 2' }
-      , finished);
-    
-    assert.response(app,
-      { url: '/one' },
-      { body: 'GET one' }
-      , finished);
-    
-    assert.response(app,
-      { url: '/two' },
-      { body: 'GET two' }
-      , finished);
-  },
-  
-  'test fn.route': function(){
-    var app = express();
-
-    app.namespace('/user/:id', function(){
-      app.get('/', function handler(req, res){
-        assert.equal('/user/:id', handler.namespace);
-        res.send(200);
-      });
-    });
-
-    assert.response(app,
-      { url: '/user/12' },
-      { body: 'OK' });
-  },
-  'test app.namespace(str, middleware, fn)': function(done){
-    var app = express(),
-        calledA = 0,
-        calledB = 0;
-    
-    function middlewareA(req,res,next){
-      calledA++;
-      next();
-    }
-
-    function middlewareB(req,res,next){
-      calledB++;
-      next();
-    }
-
-    app.namespace('/user/:id', middlewareA, function(){
-      app.get('/', function(req,res){
-        res.send('got Home');
-      });
-
-      app.get('/other', function(req,res){
-        res.send('got Other');
-      });
-
-      app.namespace('/nest', middlewareB, function(req,res){
-        app.get('/', function(req,res){
-          res.send('got Nest');
-        });
-      });
-    });
-
-    var pending = 3;
-    function finished() {
-      --pending || function(){
-        assert.equal(3, calledA);
-        assert.equal(1, calledB);
+  it('should delete() namespaced route', function(done) {
+    request(app)
+      .delete('/user/12')
+      .end(function(res) {
+        res.body.should.equal('DELETE user 12');
         done();
-      }();
-    }
+      });
+  });
 
-    assert.response(app,
-      { url: '/user/12' },
-      { body: 'got Home' }, 
-      finished);
-    assert.response(app,
-      { url: '/user/12/other' },
-      { body: 'got Other' },
-      finished);
-    assert.response(app,
-      { url: '/user/12/nest' },
-      { body: 'got Nest' },
-      finished);
+
+  it('should get() a route defined before namespaced routes', function(done) {
+    request(app)
+      .get('/one')
+      .end(function(res) {
+        res.body.should.equal('GET one');
+        done();
+      });
+  });
+
+  it('should get() a route defined after namespaced routes', function(done) {
+    request(app)
+      .get('/two')
+      .end(function(res) {
+        res.body.should.equal('GET two');
+        done();
+      });
+  });
+
+});
+
+
+
+
+describe('app.namespace(str, fn) nesting', function(){
+  var pending = 6
+    , calls = 0
+    , app = express();
+  
+  function finished() {
+    --pending || function(){
+      assert.equal(2, calls);
+    }();
   }
-};
+
+  function middleware(req, res, next) {
+    ++calls;
+    next();
+  }
+
+  app.get('/one', function(req, res){
+    res.send('GET one');
+  });
+
+  app.namespace('/forum/:id', function(){
+    app.get('/', function(req, res){
+      res.send('GET forum ' + req.params.id);
+    });
+    
+    app.get('/edit', function(req, res){
+      res.send('GET forum ' + req.params.id + ' edit page');
+    });
+
+    app.namespace('/thread', function(){
+      app.get('/:tid', middleware, middleware, function(req, res){
+        res.send('GET forum ' + req.params.id + ' thread ' + req.params.tid);
+      });
+    });
+
+    app.del('/', function(req, res){
+      res.send('DELETE forum ' + req.params.id);
+    });
+  });
+  
+  app.get('/two', function(req, res){
+    res.send('GET two');
+  });
+
+
+  it('should get() /forum/1', function(done) {
+    request(app)
+      .get('/forum/1')
+      .end(function(res) {
+        res.body.should.equal('GET forum 1');
+        finished();
+        done();
+      });
+  });
+
+  it('should get() /forum/1/edit', function(done) {
+    request(app)
+      .get('/forum/1/edit')
+      .end(function(res) {
+        res.body.should.equal('GET forum 1 edit page');
+        finished();
+        done();
+      });
+  });
+
+  it('should get() /forum/1/thread/50', function(done) {
+    request(app)
+      .get('/forum/1/thread/50')
+      .end(function(res) {
+        res.body.should.equal('GET forum 1 thread 50');
+        finished();
+        done();
+      });
+  });
+
+  it('should delete() /forum/2', function(done) {
+    request(app)
+      .delete('/forum/2')
+      .end(function(res) {
+        res.body.should.equal('DELETE forum 2');
+        finished();
+        done();
+      });
+  });
+
+
+  it('should get() a route defined before namespaced routes', function(done) {
+    request(app)
+      .get('/one')
+      .end(function(res) {
+        res.body.should.equal('GET one');
+        finished();
+        done();
+      });
+  });
+
+  it('should get() a route defined after namespaced routes', function(done) {
+    request(app)
+      .get('/two')
+      .end(function(res) {
+        res.body.should.equal('GET two');
+        finished();
+        done();
+      });
+  });
+
+});
+
+
+
+
+describe('fn.route', function(){
+  var app = express();
+
+  app.namespace('/user/:id', function(){
+    app.get('/', function handler(req, res){
+      assert.equal('/user/:id', handler.namespace);
+      res.send(200);
+    });
+  });
+
+  it('should get() /user/12', function(done) {
+    request(app)
+      .get('/user/12')
+      .end(function(res) {
+        res.body.should.equal('OK');
+        done();
+      });
+  });
+
+});
+
+describe('app.namespace(str, middleware, fn)', function(){
+  var app = express(),
+      calledA = 0,
+      calledB = 0;
+  
+  function middlewareA(req,res,next){
+    calledA++;
+    next();
+  }
+
+  function middlewareB(req,res,next){
+    calledB++;
+    next();
+  }
+
+  app.namespace('/user/:id', middlewareA, function(){
+    app.get('/', function(req,res){
+      res.send('got Home');
+    });
+
+    app.get('/other', function(req,res){
+      res.send('got Other');
+    });
+
+    app.namespace('/nest', middlewareB, function(req,res){
+      app.get('/', function(req,res){
+        res.send('got Nest');
+      });
+    });
+  });
+
+  var pending = 3;
+  function finished() {
+    --pending || function(){
+      assert.equal(3, calledA);
+      assert.equal(1, calledB);
+    }();
+  }
+
+
+  it('should get() /user/12', function(done) {
+    request(app)
+      .get('/user/12')
+      .end(function(res) {
+        res.body.should.equal('got Home');
+        finished();
+        done();
+      });
+  });
+
+  it('should get() /user/12/other', function(done) {
+    request(app)
+      .get('/user/12/other')
+      .end(function(res) {
+        res.body.should.equal('got Other');
+        finished();
+        done();
+      });
+  });
+
+  it('should get() /user/12/nest', function(done) {
+    request(app)
+      .get('/user/12/nest')
+      .end(function(res) {
+        res.body.should.equal('got Nest');
+        finished();
+        done();
+      });
+  });
+
+});
+

--- a/test/support/http.js
+++ b/test/support/http.js
@@ -1,0 +1,110 @@
+/**
+ * Grabbed in express js test suite support :
+ * https://github.com/visionmedia/express/blob/master/test/support/http.js
+ */
+
+
+/**
+ * Module dependencies.
+ */
+
+var EventEmitter = require('events').EventEmitter
+  , methods = require('express/lib/router/methods')
+  , http = require('http');
+
+module.exports = request;
+
+function request(app) {
+  return new Request(app);
+}
+
+function Request(app) {
+  var self = this;
+  this.data = [];
+  this.header = {};
+  this.app = app;
+  if (!this.server) {
+    this.server = http.Server(app);
+    this.server.listen(0, function(){
+      self.addr = self.server.address();
+      self.listening = true;
+    });
+  }
+}
+
+/**
+ * Inherit from `EventEmitter.prototype`.
+ */
+
+Request.prototype.__proto__ = EventEmitter.prototype;
+
+methods.forEach(function(method){
+  Request.prototype[method] = function(path){
+    return this.request(method, path);
+  };
+});
+
+Request.prototype.set = function(field, val){
+  this.header[field] = val;
+  return this;
+};
+
+Request.prototype.write = function(data){
+  this.data.push(data);
+  return this;
+};
+
+Request.prototype.request = function(method, path){
+  this.method = method;
+  this.path = path;
+  return this;
+};
+
+Request.prototype.expect = function(body, fn){
+  this.end(function(res){
+    if ('number' == typeof body) {
+      res.statusCode.should.equal(body);
+    } else if (body instanceof RegExp) {
+      res.body.should.match(body);
+    } else {
+      res.body.should.equal(body);
+    }
+    fn();
+  });
+};
+
+Request.prototype.end = function(fn){
+  var self = this;
+
+  if (this.listening) {
+    var req = http.request({
+        method: this.method
+      , port: this.addr.port
+      , host: this.addr.address
+      , path: this.path
+      , headers: this.header
+    });
+
+    this.data.forEach(function(chunk){
+      req.write(chunk);
+    });
+    
+    req.on('response', function(res){
+      var buf = '';
+      res.setEncoding('utf8');
+      res.on('data', function(chunk){ buf += chunk });
+      res.on('end', function(){
+        res.body = buf;
+        fn(res);
+      });
+    });
+
+    req.end();
+  } else {
+    this.server.on('listening', function(){
+      self.end(fn);
+    });
+  }
+
+  return this;
+};


### PR DESCRIPTION
This path work nice on my project using Express 3.0.0alpha2 and node v0.6.16 :

1) Prevent applying namespace on application.get() when used as a simple getter rather than a get route

2) Do not using currentNamespace property getter (I don't know why, the return value is wrong ??)

The test suite still not work but it look like to be an expresso failure related to assert.response() and Express or node v0.6.x (?)

Maybe related to https://github.com/visionmedia/express-namespace/issues/6

Hoping that will help !