### PR TITLE
Adding a default callback function to guard for when proxied methods being called without a callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@
 
 var express = require('express')
   , join = require('path').join
+  , noOp = function(req, res, next) { next(); }
   , HTTPServer = express.HTTPServer
   , HTTPSServer = express.HTTPSServer;
 
@@ -56,7 +57,7 @@ express.router.methods.concat('del').forEach(function(method){
   exports[method] = function(){
     var args = Array.prototype.slice.call(arguments)
       , path = args.shift()
-      , fn = args.pop()
+      , fn = args.pop() || noOp
       , self = this;
 
     this.namespace(path, function(){

--- a/test/namespace.test.js
+++ b/test/namespace.test.js
@@ -7,6 +7,15 @@ var express = require('express')
   , namespace = require('../');
 
 module.exports = {
+  'test proxy methods being called without a callback function': function() {
+    var app = express.createServer();
+    assert.doesNotThrow(function() {
+      app.get('/something');
+    });
+
+    assert.equal(app.get('/something'), app);
+  },
+
   'test app.namespace(str, fn)': function(){
     var app = express.createServer()
       , id;


### PR DESCRIPTION
I was running into an issue where express-namespace was having a conflict with nested resources from express-resource.

The error was stating that it couldn't add the property 'namespace' to undefined on line 70 of index.js.

This was being triggered by the express-resource plugin in the "add" method, where it would do something like:

app[method](key).remove()

...which would effectively be calling app.get('/path') but without a callback function, which would get actually end up calling the proxy wrapper in express-namespace, which would blow up when trying to add the namespace property to that undefined function.

I'm not sure if this is reasonable behavior (ie - calling app.get('/path') without a callback). If it _is_ reasonable, then this pull request makes sense to include here as it would make express-namespace tolerant of that api. If not, then this pull request can be ignored, though, we should probably add an empty callback function to the "add" method in the express-resource plugin to ensure that app.get is always called with a callback. I'll be submitting a pull request to that project that accomplishes this shortly.

Thanks
