### PR TITLE
Adds middleware for serving static files within a namespace

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,6 +75,16 @@ exports.__defineGetter__('currentNamespace', function(){
   };
 });
 
+namespace = exports.currentNamespace;
+exports.namespaceUrl = function namespaceUrl(){
+  return function namespaceUrl(req, res, next){
+    if(req.url.match("^" + currentNamespace) && req.method == "GET"){
+      req.url = req.url.replace(currentNamespace, "");
+    }
+    next();
+  };
+}
+
 // merge
 
 for (var key in exports) {


### PR DESCRIPTION
I needed to namespace an entire app that also uses `express.static` to serve up static files. This change allows the static files to be namespaced as well as the rest of the routes.
