### PR TITLE
ignore non-string routes

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ methods.forEach(function(method){
         , self = this;
 
       this.namespace(path, function(){
-	  	path = 'string' != typeof path ? path : this._ns.join('/').replace(/\/\//g, '/').replace(/\/$/, '') || '/';
+	path = 'string' != typeof path ? path : this._ns.join('/').replace(/\/\//g, '/').replace(/\/$/, '') || '/';
         args.forEach(function(fn){
           orig.call(self, path, fn);
         });

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ methods.forEach(function(method){
         , self = this;
 
       this.namespace(path, function(){
-        path = this._ns.join('/').replace(/\/\//g, '/').replace(/\/$/, '') || '/';
+	  	path = 'string' != typeof path ? path : this._ns.join('/').replace(/\/\//g, '/').replace(/\/$/, '') || '/';
         args.forEach(function(fn){
           orig.call(self, path, fn);
         });

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ methods.forEach(function(method){
         , self = this;
 
       this.namespace(path, function(){
-	path = 'string' != typeof path ? path : this._ns.join('/').replace(/\/\//g, '/').replace(/\/$/, '') || '/';
+        path = 'string' != typeof path ? path : this._ns.join('/').replace(/\/\//g, '/').replace(/\/$/, '') || '/';
         args.forEach(function(fn){
           orig.call(self, path, fn);
         });

--- a/test/namespace.test.js
+++ b/test/namespace.test.js
@@ -106,4 +106,36 @@ describe('app.namespace(path, fn)', function(){
     .get('/forum/23')
     .expect('23', done);
   })
+
+	it('should not die with regexes, but they ignore namespacing', function(done){
+		var app = express();
+		done = pending(2, done);
+
+		app.get(/test\d\d\d/, function(req, res) {
+			res.send("GET test");
+		});
+
+		app.namespace('/forum/:id', function(){
+			app.get('/', function(req, res){
+				res.send('' + req.params.id);
+			});
+		});
+
+		app.get(/^\/(?!login$|account\/login$|logout$)(.*)/, function(req, res) {
+			res.send("crazy reg");
+		});
+
+		request(app)
+			.get('/forum/23')
+			.expect('23', done);
+
+		request(app)
+			.get('/test123')
+			.expect('GET test', done);
+
+		request(app)
+			.get('/account/123')
+			.expect('crazy reg', done);
+	})
+
 })

--- a/test/namespace.test.js
+++ b/test/namespace.test.js
@@ -109,7 +109,7 @@ describe('app.namespace(path, fn)', function(){
 
 	it('should not die with regexes, but they ignore namespacing', function(done){
 		var app = express();
-		done = pending(2, done);
+		done = pending(3, done);
 
 		app.get(/test\d\d\d/, function(req, res) {
 			res.send("GET test");

--- a/test/namespace.test.js
+++ b/test/namespace.test.js
@@ -116,13 +116,15 @@ describe('app.namespace(path, fn)', function(){
 		});
 
 		app.namespace('/forum/:id', function(){
+
 			app.get('/', function(req, res){
 				res.send('' + req.params.id);
 			});
-		});
 
-		app.get(/^\/(?!login$|account\/login$|logout$)(.*)/, function(req, res) {
-			res.send("crazy reg");
+			app.get(/^\/(?!login$|account\/login$|logout$)(.*)/, function(req, res) {
+				res.send("crazy reg");
+			});
+
 		});
 
 		request(app)


### PR DESCRIPTION
just ignore routes that aren't string. fixes #5, #21
