### PR TITLE
Added `exports.init` to allow `namespace` to be added to an express Server instance

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,16 +33,17 @@ var namespace = exports.namespace = function(){
   return this;
 };
 
-apps.forEach(function(app){
-  app.namespace = namespace;
-});
-
 /**
- * Proxy HTTP methods to provide namespacing support.
+ * Add the `namespace` method to the provided `app`, and proxy the HTTP methods
+ * to provide namespacing support
+ * @param {Server} app
+ * @return {Server} for chaining
+ * @api public
  */
-
-methods.forEach(function(method){
-  apps.forEach(function(app){
+var init = exports.init = function(app){
+  app.namespace = namespace;
+  // Proxy HTTP methods to provide namespacing support
+  methods.forEach(function(method){
     var orig = app[method];
     app[method] = function(val){
       var len = arguments.length;
@@ -62,4 +63,7 @@ methods.forEach(function(method){
       return this;
     };
   });
-});
+  return app;
+};
+
+apps.forEach(init);


### PR DESCRIPTION
I have an app where express Server instances are created in another module, which has its own instance of the `express` module, so they don't have the `namespace` method. This change allows me to call `require('express-namespace').init(app)` to add the method.
