### PR TITLE
define one route per unique path

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,9 +54,8 @@ methods.forEach(function(method){
 
       this.namespace(path, function(){
         path = this._ns.join('/').replace(/\/\//g, '/').replace(/\/$/, '') || '/';
-        args.forEach(function(fn){
-          orig.call(self, path, fn);
-        });
+        args.unshift(path);
+        orig.apply(self, args);
       });
 
       return this;

--- a/package.json
+++ b/package.json
@@ -1,23 +1,23 @@
 {
-    "name": "express-namespace",
-    "description": "Express namespaced routes extension",
-    "version": "0.1.1",
-    "author": "TJ Holowaychuk <tj@vision-media.ca>",
-    "keywords": [
-        "express"
-    ],
-    "main": "index",
-    "dependencies": {
-        "methods": "0.0.1"
-    },
-    "devDependencies": {
-        "express": "3.x",
-        "ejs": "*",
-        "mocha": "*",
-        "supertest": "*"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/visionmedia/express-namespace.git"
-    }
+  "name": "express-namespace",
+  "description": "Express namespaced routes extension",
+  "version": "0.1.2",
+  "author": "TJ Holowaychuk <tj@vision-media.ca>",
+  "keywords": [
+    "express"
+  ],
+  "main": "index",
+  "dependencies": {
+    "methods": "0.0.1"
+  },
+  "devDependencies": {
+    "express": "3.x",
+    "ejs": "*",
+    "mocha": "*",
+    "supertest": "*"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/visionmedia/express-namespace.git"
+  }
 }

--- a/test/namespace.test.js
+++ b/test/namespace.test.js
@@ -29,7 +29,7 @@ describe('app.namespace(path, fn)', function(){
     request(app)
     .get('/some/two')
     .expect('GET two', done);
-  })
+  });
 
   it('should prefix within .namespace()', function(done){
     var app = express();
@@ -52,12 +52,12 @@ describe('app.namespace(path, fn)', function(){
         app.del('/all', function(req, res){
           res.send('DELETE all baz');
         });
-      })
+      });
 
       app.get('/bar', function(req, res){
         res.send('bar');
       });
-    })
+    });
 
     app.get('/some/two', function(req, res){
       res.send('GET two');
@@ -86,7 +86,7 @@ describe('app.namespace(path, fn)', function(){
     request(app)
     .get('/foo/bar')
     .expect('bar', done);
-  })
+  });
 
   it('should support middleware', function(done){
     var app = express();
@@ -105,5 +105,29 @@ describe('app.namespace(path, fn)', function(){
     request(app)
     .get('/forum/23')
     .expect('23', done);
-  })
-})
+  });
+
+  it('should register paths once for all middleware', function(done){
+    var app = express();
+
+    function a(req, res, next) {
+      next('route');
+    }
+
+    function b(req, res, next) {
+      res.send(500);
+    }
+
+    app.namespace('/forum/:id', function(){
+      app.get('/', a, b);
+    });
+
+    app.get('/forum/:id', function(req, res){
+      res.send('' + req.params.id);
+    });
+
+    request(app)
+    .get('/forum/23')
+    .expect('23', done);
+  });
+});


### PR DESCRIPTION
The motivation behind this change is to play nicely with `next('route')` in express. Currently, multiple routes are being registered for the same path so if your middleware calls `next('route')` it does not bypass the remaining callbacks.

[Here is an example project to see the changes in action](https://github.com/maxbeatty/example-express-namespace-next-route)

fixes #32
